### PR TITLE
Cache control update

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ endif::[]
 
 - Added transaction_name to reported error to allow grouping by transaction name {pull}1267[#1267]
 - Added ability to query server for version (useful in the future) {pull}1278[#1278]
+- Added instrumentation for https://github.com/zendesk/racecar/ Racecar Kafka library {pull}1284[#1284]
 
 ===== Changed
 

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'json-schema', require: nil
 gem 'mongo', require: nil
 gem 'opentracing', require: nil
 gem 'rake', '>= 13.0', require: nil
+gem 'racecar', require: nil
 gem 'resque', require: nil
 gem 'sequel', require: nil
 gem 'shoryuken', require: nil

--- a/lib/elastic_apm/central_config.rb
+++ b/lib/elastic_apm/central_config.rb
@@ -181,9 +181,9 @@ module ElasticAPM
           DEFAULT_MAX_AGE
         end
 
-      if seconds < DEFAULT_MAX_AGE
+      if seconds < 5
         debug "Next fetch is too low (#{seconds}s) - increasing to default"
-        seconds = DEFAULT_MAX_AGE
+        seconds = 5
       end
 
       @scheduled_task =

--- a/lib/elastic_apm/config.rb
+++ b/lib/elastic_apm/config.rb
@@ -159,6 +159,7 @@ module ElasticAPM
         mongo
         net_http
         rake
+        racecar
         redis
         resque
         s3

--- a/lib/elastic_apm/span/context.rb
+++ b/lib/elastic_apm/span/context.rb
@@ -28,7 +28,8 @@ module ElasticAPM
         labels: {},
         sync: nil,
         message: nil,
-        service: nil
+        service: nil,
+        links: nil
       )
         @sync = sync
         @db = db && Db.new(**db)
@@ -49,6 +50,11 @@ module ElasticAPM
           when Service then service
           when Hash then Service.new(**service)
           end
+        @links =
+          case links
+          when Links then links
+          when Array then Links.new(links)
+          end
       end
 
       attr_reader(
@@ -56,7 +62,8 @@ module ElasticAPM
         :http,
         :labels,
         :sync,
-        :message
+        :message,
+        :links
       )
 
       attr_accessor :destination, :service
@@ -69,3 +76,5 @@ require 'elastic_apm/span/context/http'
 require 'elastic_apm/span/context/destination'
 require 'elastic_apm/span/context/message'
 require 'elastic_apm/span/context/service'
+require 'elastic_apm/span/context/links'
+

--- a/lib/elastic_apm/span/context/links.rb
+++ b/lib/elastic_apm/span/context/links.rb
@@ -1,0 +1,32 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+module ElasticAPM
+    class Span
+      class Context
+        # @api private
+        class Links < Array
+          # @api private
+          class Link < Struct.new(:trace_id, :span_id)
+          end
+        end
+      end
+    end
+  end
+  

--- a/lib/elastic_apm/spies/racecar.rb
+++ b/lib/elastic_apm/spies/racecar.rb
@@ -1,0 +1,77 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+begin
+require 'active_support/notifications'
+require 'active_support/subscriber'
+
+  # frozen_string_literal: true
+  module ElasticAPM
+    # @api private
+    module Spies
+      # @api private
+      class RacecarSpy
+        TYPE = 'kafka'
+        SUBTYPE = 'racecar'
+
+        # @api private
+        class ConsumerSubscriber < ActiveSupport::Subscriber
+          def start_process_message(event)
+            start_process_transaction(event: event, kind: 'process_message')
+          end
+          def process_message(_event)
+            ElasticAPM.end_transaction
+          end
+
+          def start_process_batch(event)
+            start_process_transaction(event: event, kind: 'process_batch')
+          end
+          def process_batch(_event)
+            ElasticAPM.end_transaction
+          end
+
+          private # only public methods will be subscribed
+
+          def start_process_transaction(event:, kind:)
+            ElasticAPM.start_transaction(kind, TYPE)
+            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar', framework_version: Racecar::VERSION)
+          end
+        end
+
+        class ProducerSubscriber < ActiveSupport::Subscriber
+          def start_deliver_message(event)
+            ElasticAPM.start_transaction('deliver_message',TYPE)
+            ElasticAPM.current_transaction.context.set_service(framework_name: 'racecar', framework_version: Racecar::VERSION)
+          end
+
+          def deliver_message(_event)
+            ElasticAPM.end_transaction
+          end
+        end
+
+        def install
+          ConsumerSubscriber.attach_to(:racecar)
+          ProducerSubscriber.attach_to(:racecar)
+        end
+      end
+      register 'Racecar', 'racecar', RacecarSpy.new
+    end
+  end
+
+rescue LoadError
+  # no active support available
+end

--- a/lib/elastic_apm/spies/sqs.rb
+++ b/lib/elastic_apm/spies/sqs.rb
@@ -56,6 +56,7 @@ module ElasticAPM
             service: { resource: "#{SUBTYPE}/#{queue_name}" },
             cloud: { region: region }
           }
+          # span links added here?
         )
       end
 

--- a/lib/elastic_apm/transport/serializers/span_serializer.rb
+++ b/lib/elastic_apm/transport/serializers/span_serializer.rb
@@ -73,6 +73,10 @@ module ElasticAPM
               base[:service] = build_service(context.service)
             end
 
+            if context.links && !context.links.empty?
+              base[:links] = build_links(context.links)
+            end
+
             base
           end
 
@@ -132,6 +136,14 @@ module ElasticAPM
                 name: keyword_field(service.target&.name),
                 type: keyword_field(service.target&.type)
               }
+            }
+          end
+
+          def build_links(links)
+            {
+              links: links.map do |link|
+                {"trace_id" => link.trace_id, "span_id" => link.span_id}
+              end
             }
           end
         end

--- a/spec/elastic_apm/spies/racecar_spec.rb
+++ b/spec/elastic_apm/spies/racecar_spec.rb
@@ -1,0 +1,45 @@
+# Licensed to Elasticsearch B.V. under one or more contributor
+# license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright
+# ownership. Elasticsearch B.V. licenses this file to you under
+# the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+begin
+  require 'active_support/notifications'
+  require "active_support/subscriber"
+  require 'racecar'
+
+  module ElasticAPM
+    RSpec.describe 'Spy: Racecar', :intercept do
+      it 'captures the instrumentation' do
+        with_agent do
+          ActiveSupport::Notifications.instrument('start_process_message.racecar')
+          ActiveSupport::Notifications.instrument('process_message.racecar') do
+            # this is the body of the racecar consumer #process method
+          end
+          first_transaction = @intercepted.transactions.first
+          expect(first_transaction).not_to be_nil
+          expect(first_transaction.name).to eq('process_message')
+          expect(first_transaction.type).to eq('kafka')
+        end
+      end
+    end
+  end
+
+rescue LoadError # in case we don't have ActiveSupport
+end

--- a/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
+++ b/spec/elastic_apm/transport/serializers/span_serializer_spec.rb
@@ -82,7 +82,8 @@ module ElasticAPM
                   http: { url: 'dsa' },
                   sync: false,
                   labels: { foo: 'bar' },
-                  service: {target: {name: 'test', type: 'db'}}
+                  service: {target: {name: 'test', type: 'db'}},
+                  links: [Span::Context::Links::Link.new(trace_id: 'abc', span_id: '123')]
                 )
               )
             end
@@ -95,6 +96,7 @@ module ElasticAPM
               expect(result.dig(:span, :context, :tags, :foo)).to eq 'bar'
               expect(result.dig(:span, :context, :service, :target, :name)).to eq 'test'
               expect(result.dig(:span, :context, :service, :target, :type)).to eq 'db'
+              expect(result.dig(:span, :context, :links).length).to eq 1
             end
 
             context 'with rows_affected' do


### PR DESCRIPTION
Update the existing cache control changes with a smaller minimum time - this will follow the existing spec for age. This PR also includes recent updates to elastic:main branch